### PR TITLE
can disable the captcha

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -27,6 +27,12 @@ abstract class Captcha
 
     public function verify()
     {
+        if (request()->boolean('disable_captcha', false)) {
+            $this->data = collect(['success' => true]);
+
+            return $this;
+        }
+
         $query = [
             'secret' => $this->getSecret(),
             'response' => $this->getResponseToken(),


### PR DESCRIPTION
Missed something in previous PR.

In some cases it would be nice to be able to disable the captcha, like if doing something via AJAX.

Allow the user to send a `disable_captcha` set to `true` to not check it (cuz it won't be there).