### PR TITLE
Allow skipping verification for Collections

### DIFF
--- a/src/Listeners/ValidateEntry.php
+++ b/src/Listeners/ValidateEntry.php
@@ -43,7 +43,7 @@ class ValidateEntry
             return false;
         }
 
-        $skipFields = array_merge(['_token', 'g-recaptcha-response'], $config['skip_fields'] ?? []);
+        $skipFields = array_merge(['_token'], $config['skip_fields'] ?? []);
 
         return ! empty(request()->except($skipFields));
     }

--- a/src/Listeners/ValidateEntry.php
+++ b/src/Listeners/ValidateEntry.php
@@ -43,7 +43,9 @@ class ValidateEntry
             return false;
         }
 
-        return ! empty(request()->except($config['skip_fields'] ?? []));
+        $skipFields = array_merge(['_token', 'g-recaptcha-response'], $config['skip_fields'] ?? []);
+
+        return ! empty(request()->except($skipFields));
     }
 
     protected function getCollectionConfig(string $handle)

--- a/src/Listeners/ValidateFormSubmission.php
+++ b/src/Listeners/ValidateFormSubmission.php
@@ -21,7 +21,7 @@ class ValidateFormSubmission
         /** @var Submission */
         $submission = $event->submission;
 
-        if (! in_array($submission->form()->handle(), config('captcha.forms', []))) {
+        if (! $this->shouldVerify($submission)) {
             return $submission;
         }
 
@@ -30,5 +30,10 @@ class ValidateFormSubmission
         }
 
         return $submission;
+    }
+
+    protected function shouldVerify(Submission $submission)
+    {
+        return in_array($submission->form()->handle(), config('captcha.forms', []));
     }
 }


### PR DESCRIPTION
This PR is an alternate approach to https://github.com/aryehraber/statamic-captcha/pull/10, allowing skipping Captcha verification for certain fields using an additional config option. Eg:

```php
return [
    // ...
    'collections' => [
        'pages' => [
            'skip_fields' => ['foo', 'bar'],
        ],
        'blog',
        'other',
    ],
    // ...
];
```

@edalzell It would be great if you could review this and see if this works for your use case