### PR TITLE
listeners should return null to continue on (#21)

### DIFF
--- a/src/Listeners/ValidateEntry.php
+++ b/src/Listeners/ValidateEntry.php
@@ -23,14 +23,14 @@ class ValidateEntry
         $entry = $event->entry;
 
         if (! $this->shouldVerify($entry)) {
-            return $entry;
+            return null;
         }
 
         if ($this->captcha->verify()->invalidResponse()) {
             throw ValidationException::withMessages(['captcha' => config('captcha.error_message')]);
         }
 
-        return $entry;
+        return null;
     }
 
     protected function shouldVerify(Entry $entry)

--- a/src/Listeners/ValidateFormSubmission.php
+++ b/src/Listeners/ValidateFormSubmission.php
@@ -22,14 +22,14 @@ class ValidateFormSubmission
         $submission = $event->submission;
 
         if (! $this->shouldVerify($submission)) {
-            return $submission;
+            return null;
         }
 
         if ($this->captcha->verify()->invalidResponse()) {
             throw ValidationException::withMessages(['captcha' => config('captcha.error_message')]);
         }
 
-        return $submission;
+        return null;
     }
 
     protected function shouldVerify(Submission $submission)

--- a/src/Listeners/ValidateUserLogin.php
+++ b/src/Listeners/ValidateUserLogin.php
@@ -20,14 +20,14 @@ class ValidateUserLogin
         $user = $event->user;
 
         if (! $this->shouldVerify()) {
-            return $user;
+            return null;
         }
 
         if ($this->captcha->verify()->invalidResponse()) {
             throw ValidationException::withMessages(['captcha' => config('captcha.error_message')]);
         }
 
-        return $user;
+        return null;
     }
 
     protected function shouldVerify()

--- a/src/Listeners/ValidateUserRegistration.php
+++ b/src/Listeners/ValidateUserRegistration.php
@@ -20,14 +20,14 @@ class ValidateUserRegistration
         $user = $event->user;
 
         if (! $this->shouldVerify()) {
-            return $user;
+            return null;
         }
 
         if ($this->captcha->verify()->invalidResponse()) {
             throw ValidationException::withMessages(['captcha' => config('captcha.error_message')]);
         }
 
-        return $user;
+        return null;
     }
 
     protected function shouldVerify()


### PR DESCRIPTION
Listeners should return `null` if they want the event to continue propagating.