### PR TITLE
Add Localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ package.json
 mix-manifest.json
 webpack.mix.js
 yarn.lock
+
+# Editors
+.idea

--- a/README.md
+++ b/README.md
@@ -87,3 +87,18 @@ Note: using Invisible Captcha will require you to display links to the Captcha s
 ## User Registration & Login
 
 Captcha can also verify [User Registration](https://statamic.dev/tags/user-register_form) & [User Login](https://statamic.dev/tags/user-login_form) form requests, simply set `user_registration` / `user_login` to `true` inside Captcha's config and use the `{{ captcha }}` tag as normal inside Statamic's `{{ user:register_form }}` / `{{ user:login_form }}` tags.
+
+## Translations
+
+This package is localized to English and German.
+If you need translations in another language, you can create them yourself:
+
+* Create the translations file in `resources/lang/vendor/statamic-captcha/{language}/messages.php`.
+* You can use the [English translation file](https://github.com/aryehraber/statamic-captcha/blob/master/resources/lang/en/messages.php) as a blueprint.
+* You are welcome to share your translations here by [submitting a PR](https://github.com/aryehraber/statamic-captcha/pulls).
+
+If you want to change existing messages, you can publish and override them:
+
+```
+php please vendor:publish --tag="captcha-translations"
+```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ return [
     'forms' => [],
     'user_login' => false,
     'user_registration' => false,
-    'error_message' => 'Captcha failed.',
     'disclaimer' => '',
     'invisible' => false,
     'hide_badge' => false,

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -8,7 +8,6 @@ return [
     'forms' => [],
     'user_login' => false,
     'user_registration' => false,
-    'error_message' => 'Captcha failed.',
     'disclaimer' => '',
     'invisible' => false,
     'hide_badge' => false,

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'validation_error' => 'Captcha fehlgeschlagen.'
+];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'validation_error' => 'Captcha failed.'
+];

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -77,7 +77,7 @@ abstract class Captcha
     public function throwIfInvalid()
     {
         if ($this->invalidResponse()) {
-            throw ValidationException::withMessages(['captcha' => config('captcha.error_message')]);
+            throw ValidationException::withMessages(['captcha' => __('statamic-captcha::messages.validation_error')]);
         }
     }
 

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -77,7 +77,15 @@ abstract class Captcha
     public function throwIfInvalid()
     {
         if ($this->invalidResponse()) {
-            throw ValidationException::withMessages(['captcha' => __('statamic-captcha::messages.validation_error')]);
+            $message = __('statamic-captcha::messages.validation_error');
+
+            // Fallback for the old way of customizing the error message before github.com/aryehraber/statamic-captcha/pull/30
+            $legacyMessage = config('captcha.error_message');
+            if (!is_null($legacyMessage) && $legacyMessage !== 'Captcha failed.') {
+                $message = $legacyMessage;
+            }
+
+            throw ValidationException::withMessages(['captcha' => $message]);
         }
     }
 

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -2,6 +2,7 @@
 
 namespace AryehRaber\Captcha;
 
+use Illuminate\Validation\ValidationException;
 use GuzzleHttp\Client;
 
 abstract class Captcha
@@ -68,6 +69,16 @@ abstract class Captcha
     public function invalidResponse()
     {
         return ! $this->validResponse();
+    }
+
+    /**
+     * @throws ValidationException if the validation failed.
+     */
+    public function throwIfInvalid()
+    {
+        if ($this->invalidResponse()) {
+            throw ValidationException::withMessages(['captcha' => config('captcha.error_message')]);
+        }
     }
 
     /**

--- a/src/CaptchaServiceProvider.php
+++ b/src/CaptchaServiceProvider.php
@@ -49,6 +49,6 @@ class CaptchaServiceProvider extends AddonServiceProvider
 
         $this->publishes([
             __DIR__.'/../resources/lang' => resource_path('lang/vendor/statamic-captcha'),
-        ], 'statamic-captcha-translations');
+        ], 'captcha-translations');
     }
 }

--- a/src/CaptchaServiceProvider.php
+++ b/src/CaptchaServiceProvider.php
@@ -24,6 +24,13 @@ class CaptchaServiceProvider extends AddonServiceProvider
         'web' => __DIR__.'/../routes/web.php',
     ];
 
+    public function boot()
+    {
+        parent::boot();
+
+        $this->handleTranslations();
+    }
+
     public function register()
     {
         $this->app->bind(Captcha::class, function () {
@@ -34,5 +41,14 @@ class CaptchaServiceProvider extends AddonServiceProvider
 
             return new $class;
         });
+    }
+
+    protected function handleTranslations()
+    {
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'statamic-captcha');
+
+        $this->publishes([
+            __DIR__.'/../resources/lang' => resource_path('lang/vendor/statamic-captcha'),
+        ], 'statamic-captcha-translations');
     }
 }

--- a/src/Listeners/ValidateEntry.php
+++ b/src/Listeners/ValidateEntry.php
@@ -3,7 +3,6 @@
 namespace AryehRaber\Captcha\Listeners;
 
 use AryehRaber\Captcha\Captcha;
-use Illuminate\Validation\ValidationException;
 use Statamic\Entries\Entry;
 use Statamic\Events\EntrySaving;
 use Statamic\Statamic;
@@ -26,9 +25,7 @@ class ValidateEntry
             return null;
         }
 
-        if ($this->captcha->verify()->invalidResponse()) {
-            throw ValidationException::withMessages(['captcha' => config('captcha.error_message')]);
-        }
+        $this->captcha->verify()->throwIfInvalid();
 
         return null;
     }

--- a/src/Listeners/ValidateFormSubmission.php
+++ b/src/Listeners/ValidateFormSubmission.php
@@ -3,7 +3,6 @@
 namespace AryehRaber\Captcha\Listeners;
 
 use AryehRaber\Captcha\Captcha;
-use Illuminate\Validation\ValidationException;
 use Statamic\Events\FormSubmitted;
 use Statamic\Forms\Submission;
 
@@ -25,9 +24,7 @@ class ValidateFormSubmission
             return null;
         }
 
-        if ($this->captcha->verify()->invalidResponse()) {
-            throw ValidationException::withMessages(['captcha' => config('captcha.error_message')]);
-        }
+        $this->captcha->verify()->throwIfInvalid();
 
         return null;
     }

--- a/src/Listeners/ValidateUserLogin.php
+++ b/src/Listeners/ValidateUserLogin.php
@@ -4,7 +4,6 @@ namespace AryehRaber\Captcha\Listeners;
 
 use AryehRaber\Captcha\Captcha;
 use Illuminate\Auth\Events\Login;
-use Illuminate\Validation\ValidationException;
 
 class ValidateUserLogin
 {
@@ -23,9 +22,7 @@ class ValidateUserLogin
             return null;
         }
 
-        if ($this->captcha->verify()->invalidResponse()) {
-            throw ValidationException::withMessages(['captcha' => config('captcha.error_message')]);
-        }
+        $this->captcha->verify()->throwIfInvalid();
 
         return null;
     }

--- a/src/Listeners/ValidateUserRegistration.php
+++ b/src/Listeners/ValidateUserRegistration.php
@@ -3,7 +3,6 @@
 namespace AryehRaber\Captcha\Listeners;
 
 use AryehRaber\Captcha\Captcha;
-use Illuminate\Validation\ValidationException;
 use Statamic\Events\UserRegistering;
 
 class ValidateUserRegistration
@@ -23,9 +22,7 @@ class ValidateUserRegistration
             return null;
         }
 
-        if ($this->captcha->verify()->invalidResponse()) {
-            throw ValidationException::withMessages(['captcha' => config('captcha.error_message')]);
-        }
+        $this->captcha->verify()->throwIfInvalid();
 
         return null;
     }


### PR DESCRIPTION
Closes #28.

Since the `error_message` key is removed, **this is a minor breaking change**.

If users want to change the error message in the future, they need to publish the translation file by running `php please vendor:publish --tag="captcha-translations"`. I added a section to the readme describing this process.

During development, I more or less adapted the way translations are handled in the [Duplicator addon by Duncan McClean](https://github.com/doublethreedigital/duplicator), since it seemed pretty reasonable to me. Let me know if there is a problem somewhere.