### PR TITLE
Support passing additional tag parameters to captcha element

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -3,6 +3,7 @@
 namespace AryehRaber\Captcha;
 
 use GuzzleHttp\Client;
+use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
 
 abstract class Captcha
@@ -22,7 +23,7 @@ abstract class Captcha
 
     abstract public function getDefaultDisclaimer();
 
-    abstract public function renderIndexTag();
+    abstract public function renderIndexTag(Collection $params);
 
     abstract public function renderHeadTag();
 

--- a/src/CaptchaTags.php
+++ b/src/CaptchaTags.php
@@ -23,7 +23,7 @@ class CaptchaTags extends Tags
      */
     public function index()
     {
-        return $this->captcha->renderIndexTag();
+        return $this->captcha->renderIndexTag($this->params);
     }
 
     /**

--- a/src/Hcaptcha.php
+++ b/src/Hcaptcha.php
@@ -2,6 +2,8 @@
 
 namespace AryehRaber\Captcha;
 
+use Illuminate\Support\Collection;
+
 class Hcaptcha extends Captcha
 {
     public function getResponseToken()
@@ -19,12 +21,12 @@ class Hcaptcha extends Captcha
         return 'This site is protected by hCaptcha and its <a href="https://hcaptcha.com/privacy">Privacy Policy</a> and <a href="https://hcaptcha.com/terms">Terms of Service</a> apply.';
     }
 
-    public function renderIndexTag()
+    public function renderIndexTag(Collection $params)
     {
-        $attributes = $this->buildAttributes([
+        $attributes = $this->buildAttributes($params->merge([
             'data-sitekey' => $this->getSiteKey(),
             'data-size' => config('captcha.invisible') ? 'invisible' : '',
-        ]);
+        ]));
 
         return "<div class=\"h-captcha\" {$attributes}></div>";
     }

--- a/src/Recaptcha.php
+++ b/src/Recaptcha.php
@@ -2,6 +2,8 @@
 
 namespace AryehRaber\Captcha;
 
+use Illuminate\Support\Collection;
+
 class Recaptcha extends Captcha
 {
     public function getResponseToken()
@@ -19,12 +21,12 @@ class Recaptcha extends Captcha
         return 'This site is protected by reCAPTCHA and the Google [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms) apply.';
     }
 
-    public function renderIndexTag()
+    public function renderIndexTag(Collection $params)
     {
-        $attributes = $this->buildAttributes([
+        $attributes = $this->buildAttributes($params->merge([
             'data-sitekey' => $this->getSiteKey(),
             'data-size' => config('captcha.invisible') ? 'invisible' : '',
-        ]);
+        ]));
 
         return "<div class=\"g-recaptcha\" {$attributes}></div>";
     }


### PR DESCRIPTION
This allows you to add additional parameters to the `{{ captcha }}` tag which are then added as attributes in the HTML tag.

This is needed if you want to specify the `data-badge` Recaptcha attribute (https://developers.google.com/recaptcha/docs/invisible#render_param), or just want to add some other HTML attributes to the tag. 