### PR TITLE
Add ability to verify all forms using `all` config option

### DIFF
--- a/src/Listeners/ValidateFormSubmission.php
+++ b/src/Listeners/ValidateFormSubmission.php
@@ -31,6 +31,7 @@ class ValidateFormSubmission
 
     protected function shouldVerify(Submission $submission)
     {
-        return in_array($submission->form()->handle(), config('captcha.forms', []));
+        return config('captcha.forms') === 'all'
+            || in_array($submission->form()->handle(), config('captcha.forms', []));
     }
 }


### PR DESCRIPTION
As discussed in #34, this PR adds an `all` config option which stops the user having to specify each form in the config for Captcha to trigger verification.