### PR TITLE
Feature/advanced should verify behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ return [
     'invisible' => false,
     'hide_badge' => false,
     'enable_api_routes' => false,
+    'advanced_should_verify' => null,
 ];
 ```
 
@@ -64,6 +65,39 @@ return [
     'forms' => 'all',
     // ...
 ];
+```
+
+You can also provide advanced logic to determine if verification should be attempted at a more advanced level. This is useful to adjust the addon's `shouldVerify` call to include app-specific behaviour - such as disabling verification based on the environment, if you want to have captcha disabled on dev, but enabled on prod, without adjusting config. 
+
+Create an invokable class within your app, and add it as the `advanced_should_verify` property in your config:
+
+```php
+<?php
+
+return [
+    // ...
+    'advanced_should_verify' => \App\Support\ShouldVerifyCaptcha::class,
+    // ...
+];
+```
+
+And within your invokable class, which accepts the `Statamic\Forms\Submission`:
+
+```php
+<?php
+
+namespace App\Support;
+
+use Statamic\Forms\Submission;
+
+class ShouldVerifyCaptcha {
+
+    public function __invoke(Submission $submission): bool {
+        // some logic about should verify based on site setup
+        // and return "true" or "false"
+        return true;
+    }
+}
 ```
 
 ## Usage

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -12,4 +12,5 @@ return [
     'invisible' => false,
     'hide_badge' => false,
     'enable_api_routes' => false,
+    'advanced_should_verify' => null,
 ];

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -12,5 +12,5 @@ return [
     'invisible' => false,
     'hide_badge' => false,
     'enable_api_routes' => false,
-    'advanced_should_verify' => null,
+    'custom_should_verify' => null,
 ];

--- a/src/Contracts/CustomShouldVerify.php
+++ b/src/Contracts/CustomShouldVerify.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace AryehRaber\Captcha\Contracts;
+
+interface CustomShouldVerify
+{
+    public function __invoke($event): ?bool;
+}

--- a/src/Listeners/CaptchaListener.php
+++ b/src/Listeners/CaptchaListener.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AryehRaber\Captcha\Listeners;
+
+use AryehRaber\Captcha\Captcha;
+
+abstract class CaptchaListener
+{
+    protected $captcha;
+
+    public function __construct(Captcha $captcha)
+    {
+        $this->captcha = $captcha;
+    }
+
+    public function handle($event)
+    {
+        if ($this->shouldVerify($event)) {
+            $this->captcha->verify()->throwIfInvalid();
+        }
+
+        return null;
+    }
+
+    abstract protected function shouldVerify($event): bool;
+}

--- a/src/Listeners/ValidateEntry.php
+++ b/src/Listeners/ValidateEntry.php
@@ -2,36 +2,18 @@
 
 namespace AryehRaber\Captcha\Listeners;
 
-use AryehRaber\Captcha\Captcha;
 use Statamic\Entries\Entry;
 use Statamic\Events\EntrySaving;
 use Statamic\Statamic;
 
-class ValidateEntry
+class ValidateEntry extends CaptchaListener
 {
-    protected $captcha;
-
-    public function __construct(Captcha $captcha)
-    {
-        $this->captcha = $captcha;
-    }
-
-    public function handle(EntrySaving $event)
+    /** @param EntrySaving $event */
+    protected function shouldVerify($event): bool
     {
         /** @var Entry */
         $entry = $event->entry;
 
-        if (! $this->shouldVerify($entry)) {
-            return null;
-        }
-
-        $this->captcha->verify()->throwIfInvalid();
-
-        return null;
-    }
-
-    protected function shouldVerify(Entry $entry)
-    {
         if (Statamic::isCpRoute()) {
             return false;
         }

--- a/src/Listeners/ValidateFormSubmission.php
+++ b/src/Listeners/ValidateFormSubmission.php
@@ -31,7 +31,14 @@ class ValidateFormSubmission
 
     protected function shouldVerify(Submission $submission)
     {
-        return config('captcha.forms') === 'all'
+        $shouldVerify = config('captcha.forms') === 'all'
             || in_array($submission->form()->handle(), config('captcha.forms', []));
+ray($shouldVerify);
+        if ($shouldVerify && config('captcha.advanced_should_verify', null)) {
+            $shouldVerify = app()->make(config('captcha.advanced_should_verify'))($submission);
+        }
+
+        ray('shouldVerify: '.$shouldVerify);
+        return $shouldVerify;
     }
 }

--- a/src/Listeners/ValidateFormSubmission.php
+++ b/src/Listeners/ValidateFormSubmission.php
@@ -2,35 +2,17 @@
 
 namespace AryehRaber\Captcha\Listeners;
 
-use AryehRaber\Captcha\Captcha;
 use Statamic\Events\FormSubmitted;
 use Statamic\Forms\Submission;
 
-class ValidateFormSubmission
+class ValidateFormSubmission extends CaptchaListener
 {
-    protected $captcha;
-
-    public function __construct(Captcha $captcha)
-    {
-        $this->captcha = $captcha;
-    }
-
-    public function handle(FormSubmitted $event)
+    /** @param FormSubmitted $event */
+    protected function shouldVerify($event): bool
     {
         /** @var Submission */
         $submission = $event->submission;
 
-        if (! $this->shouldVerify($submission)) {
-            return null;
-        }
-
-        $this->captcha->verify()->throwIfInvalid();
-
-        return null;
-    }
-
-    protected function shouldVerify(Submission $submission)
-    {
         $shouldVerify = config('captcha.forms') === 'all'
             || in_array($submission->form()->handle(), config('captcha.forms', []));
 

--- a/src/Listeners/ValidateFormSubmission.php
+++ b/src/Listeners/ValidateFormSubmission.php
@@ -37,7 +37,7 @@ class ValidateFormSubmission
         if ($shouldVerify && config('captcha.advanced_should_verify', null)) {
             $shouldVerify = app()->make(config('captcha.advanced_should_verify'))($submission);
         }
-        
+
         return $shouldVerify;
     }
 }

--- a/src/Listeners/ValidateFormSubmission.php
+++ b/src/Listeners/ValidateFormSubmission.php
@@ -33,12 +33,11 @@ class ValidateFormSubmission
     {
         $shouldVerify = config('captcha.forms') === 'all'
             || in_array($submission->form()->handle(), config('captcha.forms', []));
-ray($shouldVerify);
+
         if ($shouldVerify && config('captcha.advanced_should_verify', null)) {
             $shouldVerify = app()->make(config('captcha.advanced_should_verify'))($submission);
         }
-
-        ray('shouldVerify: '.$shouldVerify);
+        
         return $shouldVerify;
     }
 }

--- a/src/Listeners/ValidateUserLogin.php
+++ b/src/Listeners/ValidateUserLogin.php
@@ -2,32 +2,12 @@
 
 namespace AryehRaber\Captcha\Listeners;
 
-use AryehRaber\Captcha\Captcha;
 use Illuminate\Auth\Events\Login;
 
-class ValidateUserLogin
+class ValidateUserLogin extends CaptchaListener
 {
-    protected $captcha;
-
-    public function __construct(Captcha $captcha)
-    {
-        $this->captcha = $captcha;
-    }
-
-    public function handle(Login $event)
-    {
-        $user = $event->user;
-
-        if (! $this->shouldVerify()) {
-            return null;
-        }
-
-        $this->captcha->verify()->throwIfInvalid();
-
-        return null;
-    }
-
-    protected function shouldVerify()
+    /** @param Login $event */
+    protected function shouldVerify($event): bool
     {
         return config('captcha.user_login', false);
     }

--- a/src/Listeners/ValidateUserRegistration.php
+++ b/src/Listeners/ValidateUserRegistration.php
@@ -2,32 +2,12 @@
 
 namespace AryehRaber\Captcha\Listeners;
 
-use AryehRaber\Captcha\Captcha;
 use Statamic\Events\UserRegistering;
 
-class ValidateUserRegistration
+class ValidateUserRegistration extends CaptchaListener
 {
-    protected $captcha;
-
-    public function __construct(Captcha $captcha)
-    {
-        $this->captcha = $captcha;
-    }
-
-    public function handle(UserRegistering $event)
-    {
-        $user = $event->user;
-
-        if (! $this->shouldVerify()) {
-            return null;
-        }
-
-        $this->captcha->verify()->throwIfInvalid();
-
-        return null;
-    }
-
-    protected function shouldVerify()
+    /** @param UserRegistering $event */
+    protected function shouldVerify($event): bool
     {
         return config('captcha.user_registration', false);
     }


### PR DESCRIPTION
Thanks for such a great addon. This is an advanced use case but has come up with changes to how Laravel 11 handles events.

## Our requirements
Our specific use case is having Global-set configuration options that allow us to toggle captcha behaviour on or off based on an environment - really helpful for local dev. We have a Global that has our form config - success messages, and the like - and three toggle switches, one for Dev, Staging and Prod, that determines whether captcha should be attempted for that environment. 

## Laravel 10 and before

With Laravel 10, we could re-bind the ValidateFormSubmission listener. We created our own Listener that extended yours, and extended the `shouldVerify` behaviour to look at the Global setup and the environment, and determine if it was enabled or not. If not, we could return false and avoid verification.

## Laravel 11

However with Laravel 11, type-hinted Events are automatically registered - meaning we get both the package's listener, and our own bound listener. 

This means it runs twice, and fails as only one call succeeds.

## Suggestion

This PR suggests adding a new config option - `advanced_should_verify` - that accepts an invokable class that receives the `$submission`. This needs to return `true` or `false`.

For example, our class may look like:
```php
<?php

namespace App\Support;

use Statamic\Forms\Submission;

class ShouldVerifyCaptcha {

    public function __invoke(Submission $submission):bool {
        // get the settings
        $forms = GlobalSet::findByHandle('forms')->in(Site::current()->handle);

        // get the env
        $environment = config('app.env');

        // if the config is false, then do not validate
        if ($forms->get('forms_'.$environment, false) === false) {
            return false;
        }

        return true;
    }
}
```

When our Global config is set to have captcha disabled for the environment, it will return false, and not verify the captcha. 

In the config, you would just need to reference this:
```php
<?php

return [
    // ...
    'advanced_should_verify' => \App\Support\ShouldVerifyCaptcha::class,
    // ...
];
```

This allows a developer to add their own advanced verification enabled (or not) logic that extends the existing behaviour of forms and collections. The developer can choose to look at things like Globals, or look at the submission content itself, or even something else. It opens up additional opportunities to help extend the flexibility for those who want it, but also requires no changes for those who don't need it. 

Happy to discuss this further if you had other ideas or approaches.