### PR TITLE
Deprecated error

### DIFF
--- a/src/Listeners/CaptchaListener.php
+++ b/src/Listeners/CaptchaListener.php
@@ -36,7 +36,7 @@ abstract class CaptchaListener
     {
         $customClass = config('captcha.custom_should_verify');
 
-        if (! class_exists($customClass)) {
+        if (! $customClass || ! class_exists($customClass)) {
             return null;
         }
 


### PR DESCRIPTION
There is a deprecated error in CaptchaListener:
`class_exists(): Passing null to parameter #1 ($class) of type string is deprecated`