### PR TITLE
Add `{{ captcha:selector }}` Tag

### DIFF
--- a/src/Altcha.php
+++ b/src/Altcha.php
@@ -11,6 +11,11 @@ class Altcha extends Captcha
         return request('altcha-payload');
     }
 
+    public function getResponseSelector()
+    {
+        return '#altcha-widget input[name=altcha]';
+    }
+
     public function getVerificationUrl()
     {
         return null;

--- a/src/Altcha.php
+++ b/src/Altcha.php
@@ -42,7 +42,8 @@ class Altcha extends Captcha
 
     public function verify()
     {
-        $payload = json_decode(base64_decode($this->getResponseToken()), true);
+        $responseToken = $this->getResponseToken() ?: request('captcha-response');
+        $payload = json_decode(base64_decode($responseToken), true);
 
         if ($payload) {
             $challenge = $this->createChallenge($payload['salt'], $payload['number']);

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -33,7 +33,7 @@ abstract class Captcha
     {
         $params = [
             'secret' => $this->getSecret(),
-            'response' => $this->getResponseToken(),
+            'response' => $this->getResponseToken() ?: request('captcha-response'),
             'remoteip' => request()->ip(),
         ];
 

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -19,6 +19,8 @@ abstract class Captcha
 
     abstract public function getResponseToken();
 
+    abstract public function getResponseSelector();
+
     abstract public function getVerificationUrl();
 
     abstract public function getDefaultDisclaimer();

--- a/src/CaptchaTags.php
+++ b/src/CaptchaTags.php
@@ -2,8 +2,8 @@
 
 namespace AryehRaber\Captcha;
 
-use Statamic\Tags\Tags;
 use Statamic\Support\Html;
+use Statamic\Tags\Tags;
 
 class CaptchaTags extends Tags
 {
@@ -34,6 +34,16 @@ class CaptchaTags extends Tags
     public function head()
     {
         return $this->captcha->renderHeadTag();
+    }
+
+    /**
+     * The {{ captcha:selector }} tag
+     *
+     * @return string
+     */
+    public function selector()
+    {
+        return $this->captcha->getResponseSelector();
     }
 
     /**

--- a/src/Hcaptcha.php
+++ b/src/Hcaptcha.php
@@ -11,6 +11,11 @@ class Hcaptcha extends Captcha
         return request('h-captcha-response');
     }
 
+    public function getResponseSelector()
+    {
+        return '.h-captcha textarea[name=h-captcha-response]';
+    }
+
     public function getVerificationUrl()
     {
         return 'https://hcaptcha.com/siteverify';

--- a/src/Recaptcha.php
+++ b/src/Recaptcha.php
@@ -11,6 +11,11 @@ class Recaptcha extends Captcha
         return request('g-recaptcha-response');
     }
 
+    public function getResponseSelector()
+    {
+        return '.g-recaptcha textarea[name=g-recaptcha-response]';
+    }
+
     public function getVerificationUrl()
     {
         return 'https://www.google.com/recaptcha/api/siteverify';

--- a/src/Turnstile.php
+++ b/src/Turnstile.php
@@ -11,6 +11,11 @@ class Turnstile extends Captcha
         return request('cf-turnstile-response');
     }
 
+    public function getResponseSelector()
+    {
+        return '.cf-turnstile input[name=cf-turnstile-response]';
+    }
+
     public function getVerificationUrl()
     {
         return 'https://challenges.cloudflare.com/turnstile/v0/siteverify';


### PR DESCRIPTION
This PR is in response to issue https://github.com/aryehraber/statamic-captcha/issues/59. This will add a new tag to allow the Peak starter kit (or any other form using a JS lib and/or Precognition) to easily pluck the captcha's response value using the query selector, allowing users to set it on the form object before submission. 