### PR TITLE
Allow script url override from config

### DIFF
--- a/config/captcha.php
+++ b/config/captcha.php
@@ -13,4 +13,5 @@ return [
     'hide_badge' => false,
     'enable_api_routes' => false,
     'custom_should_verify' => null,
+    'script_url' => env('CAPTCHA_SCRIPT_URL'),
 ];

--- a/resources/views/altcha/head.blade.php
+++ b/resources/views/altcha/head.blade.php
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/altcha/dist/altcha.min.js" async defer type="module"></script>
+<script src="{{ config('captcha.script_url') ?? 'https://cdn.jsdelivr.net/npm/altcha/dist/altcha.min.js' }}" async defer type="module"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     const wrapper = document.getElementById('altcha-widget')

--- a/resources/views/hcaptcha/head.blade.php
+++ b/resources/views/hcaptcha/head.blade.php
@@ -24,4 +24,4 @@
 </script>
 @endif
 
-<script src="https://hcaptcha.com/1/api.js" async defer></script>
+<script src="{{ config('captcha.script_url') ?? 'https://hcaptcha.com/1/api.js' }}" async defer></script>

--- a/resources/views/recaptcha/head.blade.php
+++ b/resources/views/recaptcha/head.blade.php
@@ -27,4 +27,4 @@
 </script>
 @endif
 
-<script src="https://www.google.com/recaptcha/api.js" async defer></script>
+<script src="{{ config('captcha.script_url') ?? 'https://www.google.com/recaptcha/api.js' }}" async defer></script>

--- a/resources/views/turnstile/head.blade.php
+++ b/resources/views/turnstile/head.blade.php
@@ -1,1 +1,1 @@
-<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+<script src="{{ config('captcha.script_url') ?? 'https://challenges.cloudflare.com/turnstile/v0/api.js' }}" async defer></script>


### PR DESCRIPTION
This adds a config option to allow the developer to control the captcha's script URL.