### PR TITLE
Fix Altcha widget with full static caching

### DIFF
--- a/resources/views/altcha/head.blade.php
+++ b/resources/views/altcha/head.blade.php
@@ -1,11 +1,16 @@
 <script src="https://cdn.jsdelivr.net/npm/altcha/dist/altcha.min.js" async defer type="module"></script>
 <script>
-  document.addEventListener('DOMContentLoaded', function () {
+  function initAltchaWidget() {
     const wrapper = document.getElementById('altcha-widget')
+
+    if (!wrapper || wrapper.querySelector('altcha-widget')) return
+
     const captcha = document.createElement('altcha-widget')
 
     wrapper.getAttributeNames().forEach((name) => {
-      captcha.setAttribute(name, wrapper.getAttribute(name))
+      if (name !== 'id') {
+        captcha.setAttribute(name, wrapper.getAttribute(name))
+      }
     })
 
     wrapper.append(captcha)
@@ -22,5 +27,11 @@
         hiddenInput.setAttribute('value', ev.detail.payload)
       }
     })
-  })
+  }
+
+  // Initialize on DOMContentLoaded (non-cached pages)
+  document.addEventListener('DOMContentLoaded', initAltchaWidget)
+
+  // Initialize after nocache regions are replaced (statically cached pages)
+  document.addEventListener('statamic:nocache.replaced', initAltchaWidget)
 </script>


### PR DESCRIPTION
## Summary

- Fixes `Uncaught TypeError: Cannot read properties of null (reading 'getAttributeNames')` when Statamic's full static caching is enabled
- When forms are wrapped in `{{ nocache }}` sections, the `#altcha-widget` div is injected via AJAX **after** `DOMContentLoaded`, so the current script fails
- Listens for Statamic's `statamic:nocache.replaced` event to initialize the widget after nocache regions are replaced
- Keeps `DOMContentLoaded` for non-cached pages
- Guards against double initialization and avoids duplicating the `id` attribute

## Problem

With full static caching (`STATAMIC_STATIC_CACHING_STRATEGY=full`), forms are typically placed inside `{{ nocache }}` sections (they need dynamic CSRF tokens, validation state, etc.). Statamic replaces these nocache placeholders via an AJAX call to `/!/nocache` after the page loads. The Altcha head script runs on `DOMContentLoaded` before this replacement happens, so `document.getElementById('altcha-widget')` returns `null`.

## Solution

Extract initialization into `initAltchaWidget()` and call it from both:
1. `DOMContentLoaded` — works for non-cached or half-cached pages
2. `statamic:nocache.replaced` — works for fully statically cached pages where nocache regions are replaced after page load

The function guards against the element not existing yet (`!wrapper`) and against being called twice (`wrapper.querySelector('altcha-widget')`).