### PR TITLE
Add FCaptcha provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ return [
     'sitekey' => env('CAPTCHA_SITEKEY', ''),
     'secret' => env('CAPTCHA_SECRET', ''),
     'server_url' => env('CAPTCHA_SERVER_URL', ''), // required for Fcaptcha
+    'verify_ip' => env('CAPTCHA_VERIFY_IP', false), // Fcaptcha only, see below
     'forms' => [],
     'user_login' => false,
     'user_registration' => false,
@@ -68,6 +69,8 @@ CAPTCHA_SITEKEY=your-site-key
 CAPTCHA_SECRET=your-verify-secret
 CAPTCHA_SERVER_URL=https://captcha.example.com
 ```
+
+FCaptcha binds each token to the IP address it saw when the widget was solved, and rejects a token whose `remoteip` disagrees. Because that only holds when your site reports the exact same address — which needs Laravel's trusted proxies configured, and can still differ for a dual-stack visitor who reaches one host over IPv6 and the other over IPv4 — the addon does not assert an IP by default. Set `CAPTCHA_VERIFY_IP=true` to turn the check on once you've confirmed both ends agree.
 
 If you would like Captcha to verify ALL forms without having to specify each one in the `forms` config array, you may use the `all` option instead.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This addon allows you to protect your Statamic forms using any of the following 
 - [hCaptcha](https://hcaptcha.com/?r=eaeeea7cd23c)
 - [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile)
 - [ALTCHA](https://altcha.org)
+- [FCaptcha](https://github.com/WebDecoy/FCaptcha)
 
 After the initial setup, all you need to do is add the `{{ captcha }}` tag inside your forms, easy peasy!
 
@@ -30,9 +31,10 @@ Alternately, you can manually setup the config file by creating `captcha.php` in
 <?php
 
 return [
-    'service' => 'Recaptcha', // options: Recaptcha / Hcaptcha / Turnstile / Altcha
+    'service' => env('CAPTCHA_SERVICE', 'Recaptcha'), // options: Recaptcha / Hcaptcha / Turnstile / Altcha / Fcaptcha
     'sitekey' => env('CAPTCHA_SITEKEY', ''),
     'secret' => env('CAPTCHA_SECRET', ''),
+    'server_url' => env('CAPTCHA_SERVER_URL', ''), // required for Fcaptcha
     'forms' => [],
     'user_login' => false,
     'user_registration' => false,
@@ -44,18 +46,27 @@ return [
 ];
 ```
 
-Once the config file is in place, make sure to add your `sitekey` & `secret` from [Recaptcha's Console](https://www.google.com/recaptcha/admin), [hCaptcha's Console](https://dashboard.hcaptcha.com/sites), [Cloudflare's Dashboard](https://dash.cloudflare.com) or [Altcha's Docs](https://altcha.org/docs/api/api_keys/) and add the handles of the Statamic Forms you'd like to protect:
+Once the config file is in place, make sure to add your `sitekey` & `secret` from [Recaptcha's Console](https://www.google.com/recaptcha/admin), [hCaptcha's Console](https://dashboard.hcaptcha.com/sites), [Cloudflare's Dashboard](https://dash.cloudflare.com), [Altcha's Docs](https://altcha.org/docs/api/api_keys/) or your [FCaptcha server](https://github.com/WebDecoy/FCaptcha), and add the handles of the Statamic Forms you'd like to protect:
 
 ```php
 <?php
 
 return [
-    'service' => 'Recaptcha', // options: Recaptcha / Hcaptcha / Turnstile / Altcha
+    'service' => env('CAPTCHA_SERVICE', 'Recaptcha'), // options: Recaptcha / Hcaptcha / Turnstile / Altcha / Fcaptcha
     'sitekey' => 'YOUR_SITEKEY_HERE', // Or add to .env
     'secret' => 'YOUR_SECRET_HERE', // Or add to .env
     'forms' => ['contact', 'newsletter'],
     // ...
 ];
+```
+
+When using FCaptcha, also point the addon to your self-hosted FCaptcha server:
+
+```dotenv
+CAPTCHA_SERVICE=Fcaptcha
+CAPTCHA_SITEKEY=your-site-key
+CAPTCHA_SECRET=your-verify-secret
+CAPTCHA_SERVER_URL=https://captcha.example.com
 ```
 
 If you would like Captcha to verify ALL forms without having to specify each one in the `forms` config array, you may use the `all` option instead.

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "statamic",
         "recaptcha",
         "hcaptcha",
+        "fcaptcha",
         "captcha",
         "forms"
     ],

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -1,9 +1,10 @@
 <?php
 
 return [
-    'service' => 'Recaptcha', // options: Recaptcha / Hcaptcha / Turnstile / Altcha
+    'service' => env('CAPTCHA_SERVICE', 'Recaptcha'), // options: Recaptcha / Hcaptcha / Turnstile / Altcha / Fcaptcha
     'sitekey' => env('CAPTCHA_SITEKEY', ''),
     'secret' => env('CAPTCHA_SECRET', ''),
+    'server_url' => env('CAPTCHA_SERVER_URL', ''), // required for Fcaptcha
     'collections' => [],
     'forms' => [],
     'user_login' => false,

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -5,6 +5,7 @@ return [
     'sitekey' => env('CAPTCHA_SITEKEY', ''),
     'secret' => env('CAPTCHA_SECRET', ''),
     'server_url' => env('CAPTCHA_SERVER_URL', ''), // required for Fcaptcha
+    'verify_ip' => env('CAPTCHA_VERIFY_IP', false), // Fcaptcha only, see README
     'collections' => [],
     'forms' => [],
     'user_login' => false,

--- a/resources/views/fcaptcha/head.blade.php
+++ b/resources/views/fcaptcha/head.blade.php
@@ -1,0 +1,11 @@
+<script>
+  document.addEventListener('fcaptcha:verified', function (event) {
+    var responseField = event.target.getAttribute('data-response-field');
+    var input = responseField ? document.getElementById(responseField) : null;
+
+    if (input) {
+      input.value = event.detail.token;
+    }
+  });
+</script>
+<script src="{{ rtrim($serverUrl, '/') }}/fcaptcha.js" async defer></script>

--- a/resources/views/fcaptcha/head.blade.php
+++ b/resources/views/fcaptcha/head.blade.php
@@ -1,11 +1,28 @@
 <script>
-  document.addEventListener('fcaptcha:verified', function (event) {
-    var responseField = event.target.getAttribute('data-response-field');
-    var input = responseField ? document.getElementById(responseField) : null;
+  (function () {
+    function responseInput(event) {
+      var responseField = event.target.getAttribute('data-response-field');
 
-    if (input) {
-      input.value = event.detail.token;
+      return responseField ? document.getElementById(responseField) : null;
     }
-  });
+
+    // FCaptcha dispatches these on the widget container itself and the events
+    // do not bubble, so these listeners have to run in the capture phase.
+    document.addEventListener('fcaptcha:verified', function (event) {
+      var input = responseInput(event);
+
+      if (input) {
+        input.value = event.detail.token;
+      }
+    }, true);
+
+    document.addEventListener('fcaptcha:expired', function (event) {
+      var input = responseInput(event);
+
+      if (input) {
+        input.value = '';
+      }
+    }, true);
+  })();
 </script>
 <script src="{{ rtrim($serverUrl, '/') }}/fcaptcha.js" async defer></script>

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -31,19 +31,29 @@ abstract class Captcha
 
     public function verify()
     {
-        $params = [
-            'secret' => $this->getSecret(),
-            'response' => $this->getResponseToken() ?: request('captcha-response'),
-            'remoteip' => request()->ip(),
-        ];
-
-        $response = $this->client->post($this->getVerificationUrl(), ['form_params' => $params]);
+        $response = $this->client->post($this->getVerificationUrl(), [
+            'form_params' => $this->getVerificationParams(),
+        ]);
 
         if ($response->getStatusCode() == 200) {
             $this->data = collect(json_decode($response->getBody(), true));
         }
 
         return $this;
+    }
+
+    /**
+     * The parameters sent to the Captcha service for verification
+     *
+     * @return array
+     */
+    protected function getVerificationParams()
+    {
+        return [
+            'secret' => $this->getSecret(),
+            'response' => $this->getResponseToken() ?: request('captcha-response'),
+            'remoteip' => request()->ip(),
+        ];
     }
 
     /**

--- a/src/Fcaptcha.php
+++ b/src/Fcaptcha.php
@@ -21,6 +21,24 @@ class Fcaptcha extends Captcha
         return $this->getServerUrl().'/turnstile/v0/siteverify';
     }
 
+    protected function getVerificationParams()
+    {
+        $params = parent::getVerificationParams();
+
+        // FCaptcha binds a token to the IP address it saw when the widget was
+        // solved, and rejects the token outright when 'remoteip' disagrees. The
+        // two IPs are only guaranteed to match when the site and the FCaptcha
+        // server sit behind the same proxy setup: request()->ip() is the
+        // proxy's address until Laravel's trusted proxies are configured, and a
+        // dual-stack visitor can reach one host over IPv6 and the other over
+        // IPv4. Assert the IP only when the site opts in.
+        if (! config('captcha.verify_ip')) {
+            unset($params['remoteip']);
+        }
+
+        return $params;
+    }
+
     public function getDefaultDisclaimer()
     {
         return '[Protected by FCaptcha](https://github.com/WebDecoy/FCaptcha).';

--- a/src/Fcaptcha.php
+++ b/src/Fcaptcha.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace AryehRaber\Captcha;
+
+use Illuminate\Support\Collection;
+
+class Fcaptcha extends Captcha
+{
+    public function getResponseToken()
+    {
+        return request('fcaptcha_token');
+    }
+
+    public function getResponseSelector()
+    {
+        return 'input[name=fcaptcha_token]';
+    }
+
+    public function getVerificationUrl()
+    {
+        return $this->getServerUrl().'/turnstile/v0/siteverify';
+    }
+
+    public function getDefaultDisclaimer()
+    {
+        return '[Protected by FCaptcha](https://github.com/WebDecoy/FCaptcha).';
+    }
+
+    public function renderIndexTag(Collection $params)
+    {
+        $id = 'fcaptcha-'.bin2hex(random_bytes(6));
+        $responseId = $id.'-response';
+        $attributes = $this->buildAttributes($params->merge([
+            'id' => $id,
+            'class' => 'fcaptcha',
+            'data-fcaptcha' => $this->getSiteKey(),
+            'data-endpoint' => $this->getServerUrl(),
+            'data-response-field' => $responseId,
+        ]));
+
+        return "<div {$attributes}></div><input type=\"hidden\" id=\"{$responseId}\" name=\"fcaptcha_token\">";
+    }
+
+    public function renderHeadTag()
+    {
+        return view('captcha::fcaptcha.head', [
+            'serverUrl' => $this->getServerUrl(),
+        ])->render();
+    }
+
+    protected function getServerUrl()
+    {
+        return rtrim(config('captcha.server_url'), '/');
+    }
+}


### PR DESCRIPTION
## Summary

- add FCaptcha as a supported CAPTCHA service
- load the widget from a configurable self-hosted FCaptcha server
- verify tokens through FCaptcha's Turnstile-compatible Siteverify endpoint
- bridge widget verification events into isolated hidden fields, including pages with multiple forms
- document the required environment configuration

## Validation

- `git diff --check`
- `jq empty composer.json`
- reviewed the widget event/token flow against WebDecoy/FCaptcha

PHP is not installed in the current development environment, so I was unable to run a PHP syntax check or an application-level Statamic test.